### PR TITLE
Fix keyboard-controlled brick movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,6 +763,9 @@
                 }
             });
 
+            // Update movement for the currently selected block
+            updateBlockMovement();
+
             renderer.render(scene, camera);
         }
 


### PR DESCRIPTION
## Summary
- Invoke `updateBlockMovement` inside the render loop so keyboard controls move blocks in real time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2017e6fc8321a3342720203f5f2c