### PR TITLE
Prevent dragged blocks from auto-dropping in 3D Jenga game

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,12 +526,7 @@
             // Apply movement
             if (moved) {
                 selectedBlock.position.copy(selectedBlock.userData.originalPosition).add(currentOffset);
-                
-                // Check if block should be auto-removed when pulled far enough
-                const distance = currentOffset.length();
-                if (distance > 1.8) {
-                    removeBlock(selectedBlock);
-                }
+                // Player retains control; block will not be auto-removed
             }
         }
 
@@ -666,8 +661,9 @@
 
         function simulateBlockPhysics(physicsBlock) {
             const block = physicsBlock.mesh;
-            
-            if (block.userData.isRemoved) return;
+
+            // Skip physics for the block currently being controlled by the player
+            if (block.userData.isRemoved || block === selectedBlock) return;
 
             // Simple physics simulation
             let hasSupport = false;


### PR DESCRIPTION
## Summary
- Keep selected block under player control without auto-removal
- Skip physics simulation for the actively controlled block to prevent premature fall

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab36c7cdb88321a8a44a14f35076a9