### PR TITLE
Fix keyboard controls to avoid TransformControls interception

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,9 +332,9 @@
             canvas.addEventListener('wheel', onMouseWheel);
             canvas.addEventListener('click', onMouseClick);
 
-            // Keyboard events
-            document.addEventListener('keydown', onKeyDown);
-            document.addEventListener('keyup', onKeyUp);
+            // Keyboard events (use capture phase to avoid TransformControls blocking)
+            window.addEventListener('keydown', onKeyDown, true);
+            window.addEventListener('keyup', onKeyUp, true);
 
             // UI events
             document.getElementById('resetBtn').addEventListener('click', resetGame);


### PR DESCRIPTION
## Summary
- Capture keyboard events on the window during the capture phase so WASD/Space/Ctrl are recognized even with the gizmo active.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1d8f726c83219836804276f2bc3e