### PR TITLE
Ensure keyboard controls bypass TransformControls and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Instructions for human agents
+
+Thanks for contributing to the 3D Jenga game.
+
+## Code style
+- Use 4 spaces for indentation.
+- Place each statement on its own line.
+- Avoid trailing whitespace.
+
+## Testing
+- Run `npm test` and make a best effort to ensure tests pass before committing.
+
+## Pull request guidelines
+- Provide a summary of your changes and a testing section in the PR body.

--- a/index.html
+++ b/index.html
@@ -154,6 +154,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128/examples/js/controls/TransformControls.js"></script>
+    <script src="keyboard.js"></script>
     <script>
         // Game variables
         let scene, camera, renderer, world;
@@ -162,12 +163,7 @@
         let transformControls;
         let mouse = new THREE.Vector2();
         let raycaster = new THREE.Raycaster();
-        
-        // Keyboard controls
-        let keys = {
-            w: false, a: false, s: false, d: false,
-            space: false, ctrl: false, x: false
-        };
+
         let cameraControls = {
             isRotating: false,
             isPanning: false,
@@ -332,10 +328,6 @@
             canvas.addEventListener('wheel', onMouseWheel);
             canvas.addEventListener('click', onMouseClick);
 
-            // Keyboard events
-            document.addEventListener('keydown', onKeyDown);
-            document.addEventListener('keyup', onKeyUp);
-
             // UI events
             document.getElementById('resetBtn').addEventListener('click', resetGame);
 
@@ -441,42 +433,6 @@
         function onMouseUp(event) {
             cameraControls.isRotating = false;
             cameraControls.isPanning = false;
-        }
-
-        function onKeyDown(event) {
-            const key = event.key.toLowerCase();
-            
-            switch(key) {
-                case 'w': keys.w = true; break;
-                case 'a': keys.a = true; break;
-                case 's': keys.s = true; break;
-                case 'd': keys.d = true; break;
-                case ' ': 
-                    event.preventDefault(); 
-                    keys.space = true; 
-                    break;
-                case 'control': keys.ctrl = true; break;
-                case 'x': 
-                    keys.x = true;
-                    if (selectedBlock) {
-                        dropBlock(selectedBlock);
-                    }
-                    break;
-            }
-        }
-
-        function onKeyUp(event) {
-            const key = event.key.toLowerCase();
-            
-            switch(key) {
-                case 'w': keys.w = false; break;
-                case 'a': keys.a = false; break;
-                case 's': keys.s = false; break;
-                case 'd': keys.d = false; break;
-                case ' ': keys.space = false; break;
-                case 'control': keys.ctrl = false; break;
-                case 'x': keys.x = false; break;
-            }
         }
 
         function onMouseWheel(event) {

--- a/keyboard.js
+++ b/keyboard.js
@@ -1,0 +1,81 @@
+const keys = {
+    w: false,
+    a: false,
+    s: false,
+    d: false,
+    space: false,
+    ctrl: false,
+    x: false
+};
+
+function onKeyDown(event) {
+    const key = event.key.toLowerCase();
+
+    switch (key) {
+        case 'w':
+            keys.w = true;
+            break;
+        case 'a':
+            keys.a = true;
+            break;
+        case 's':
+            keys.s = true;
+            break;
+        case 'd':
+            keys.d = true;
+            break;
+        case ' ':
+            event.preventDefault();
+            keys.space = true;
+            break;
+        case 'control':
+            keys.ctrl = true;
+            break;
+        case 'x':
+            keys.x = true;
+            if (typeof dropBlock === 'function' && typeof selectedBlock !== 'undefined' && selectedBlock) {
+                dropBlock(selectedBlock);
+            }
+            break;
+    }
+}
+
+function onKeyUp(event) {
+    const key = event.key.toLowerCase();
+
+    switch (key) {
+        case 'w':
+            keys.w = false;
+            break;
+        case 'a':
+            keys.a = false;
+            break;
+        case 's':
+            keys.s = false;
+            break;
+        case 'd':
+            keys.d = false;
+            break;
+        case ' ':
+            keys.space = false;
+            break;
+        case 'control':
+            keys.ctrl = false;
+            break;
+        case 'x':
+            keys.x = false;
+            break;
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.keys = keys;
+    window.onKeyDown = onKeyDown;
+    window.onKeyUp = onKeyUp;
+    window.addEventListener('keydown', onKeyDown, { capture: true });
+    window.addEventListener('keyup', onKeyUp, { capture: true });
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { keys, onKeyDown, onKeyUp };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "3d-jenga",
+    "version": "1.0.0",
+    "scripts": {
+        "test": "node --test"
+    }
+}

--- a/test/keyboard.test.js
+++ b/test/keyboard.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const { describe, it } = require('node:test');
+const { keys, onKeyDown, onKeyUp } = require('../keyboard.js');
+
+describe('keyboard controls', () => {
+    function resetKeys() {
+        keys.w = keys.a = keys.s = keys.d = false;
+        keys.space = keys.ctrl = keys.x = false;
+    }
+
+    it('should set movement keys on keydown', () => {
+        resetKeys();
+        onKeyDown({ key: 'w', preventDefault: () => {} });
+        onKeyDown({ key: 'a', preventDefault: () => {} });
+        onKeyDown({ key: 's', preventDefault: () => {} });
+        onKeyDown({ key: 'd', preventDefault: () => {} });
+        assert.strictEqual(keys.w && keys.a && keys.s && keys.d, true);
+    });
+
+    it('should handle space and control keys', () => {
+        resetKeys();
+        onKeyDown({ key: ' ', preventDefault: () => {} });
+        onKeyDown({ key: 'Control', preventDefault: () => {} });
+        assert.strictEqual(keys.space && keys.ctrl, true);
+    });
+
+    it('should clear keys on keyup', () => {
+        resetKeys();
+        keys.w = keys.space = true;
+        onKeyUp({ key: 'w' });
+        onKeyUp({ key: ' ' });
+        assert.strictEqual(keys.w || keys.space, false);
+    });
+});


### PR DESCRIPTION
## Summary
- Register keyboard handlers before TransformControls in a new `keyboard.js` module so WASD/Space/Ctrl/X inputs are honored
- Add basic unit tests for keyboard events
- Document repository guidelines in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac1d8f726c83219836804276f2bc3e